### PR TITLE
Update ringbuffer.c

### DIFF
--- a/ringbuffer.c
+++ b/ringbuffer.c
@@ -50,7 +50,7 @@ ring_buffer_size_t ring_buffer_dequeue_arr(ring_buffer_t *buffer, char *data, ri
 
   char *data_ptr = data;
   ring_buffer_size_t cnt = 0;
-  while(ring_buffer_dequeue(buffer, data_ptr) && cnt < len) {
+  while((cnt < len) && ring_buffer_dequeue(buffer, data_ptr)) {
     cnt++;
     data_ptr++;
   }


### PR DESCRIPTION
A bug in the ring_buffer_dequeue_arr function. If ring_buffer_dequeue_arr is called consecutively then a second ring_buffer_dequeue_arr call will return the desired buffer except the first byte.
The problem was in while termination condition, as the length is checked only after a new piece of data is pulled from the buffer.
http://en.cppreference.com/w/c/language/eval_order
