### PR TITLE
Fix functions return type

### DIFF
--- a/ringbuffer.c
+++ b/ringbuffer.c
@@ -31,7 +31,7 @@ void ring_buffer_queue_arr(ring_buffer_t *buffer, const char *data, ring_buffer_
   }
 }
 
-ring_buffer_size_t ring_buffer_dequeue(ring_buffer_t *buffer, char *data) {
+uint8_t ring_buffer_dequeue(ring_buffer_t *buffer, char *data) {
   if(ring_buffer_is_empty(buffer)) {
     /* No items */
     return 0;
@@ -57,7 +57,7 @@ ring_buffer_size_t ring_buffer_dequeue_arr(ring_buffer_t *buffer, char *data, ri
   return cnt;
 }
 
-ring_buffer_size_t ring_buffer_peek(ring_buffer_t *buffer, char *data, ring_buffer_size_t index) {
+uint8_t ring_buffer_peek(ring_buffer_t *buffer, char *data, ring_buffer_size_t index) {
   if(index >= ring_buffer_num_items(buffer)) {
     /* No items at index */
     return 0;
@@ -71,5 +71,5 @@ ring_buffer_size_t ring_buffer_peek(ring_buffer_t *buffer, char *data, ring_buff
 
 extern inline uint8_t ring_buffer_is_empty(ring_buffer_t *buffer);
 extern inline uint8_t ring_buffer_is_full(ring_buffer_t *buffer);
-extern inline uint8_t ring_buffer_num_items(ring_buffer_t *buffer);
+extern inline ring_buffer_size_t ring_buffer_num_items(ring_buffer_t *buffer);
 

--- a/ringbuffer.h
+++ b/ringbuffer.h
@@ -91,7 +91,7 @@ uint8_t ring_buffer_dequeue(ring_buffer_t *buffer, char *data);
  * @param len The maximum number of bytes to return.
  * @return The number of bytes returned.
  */
-uint8_t ring_buffer_dequeue_arr(ring_buffer_t *buffer, char *data, ring_buffer_size_t len);
+ring_buffer_size_t ring_buffer_dequeue_arr(ring_buffer_t *buffer, char *data, ring_buffer_size_t len);
 /**
  * Peeks a ring buffer, i.e. returns an element without removing it.
  * @param buffer The buffer from which the data should be returned.


### PR DESCRIPTION
When i modify macro 'RING_BUFFER_SIZE' to a big value, and 'ring_buffer_size_t' to 'uint16_t', it is not running normally. 
I find that beacuse some functions return type are not right，in other words, the return type in 'ringbuffer.c' is different from 'ringbuffer.h' after change 'ring_buffer_size_t ', so i made a little modification, it work successed! and others can change 'ring_buffer_size_t' to other types if they want.