### PR TITLE
The return value of getchar must be stored in an int

### DIFF
--- a/examples/tail.c
+++ b/examples/tail.c
@@ -8,7 +8,8 @@
 #include "../ringbuffer.h"
 
 int main() {
-  char c;
+  int c;
+  char d;
   char data[16];
   struct ring_buffer_t buffer;
   ring_buffer_init(&buffer, data, sizeof(data));
@@ -16,8 +17,8 @@ int main() {
   while ((c = getchar()) != EOF)
     ring_buffer_queue(&buffer, c);
 
-  while (ring_buffer_dequeue(&buffer, &c))
-    putchar(c);
+  while (ring_buffer_dequeue(&buffer, &d))
+    putchar(d);
 
   return 0;
 }


### PR DESCRIPTION
to distinguish valid characters from EOF

Before:

```
$ printf "a\xffb" | ./tail | xxd
00000000: 61                                       a
```

After:

```
$ printf "a\xffb" | ./tail | xxd
00000000: 61ff 62                                  a.b
```

I introduced this bug in #16